### PR TITLE
Add README and metadata for collection roles

### DIFF
--- a/roles/backup/clean_up/README.md
+++ b/roles/backup/clean_up/README.md
@@ -1,0 +1,35 @@
+# Role: clean_up
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.clean_up
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/backup/clean_up/meta/main.yml
+++ b/roles/backup/clean_up/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/backup/copy_files_to_backup_host/README.md
+++ b/roles/backup/copy_files_to_backup_host/README.md
@@ -1,0 +1,35 @@
+# Role: copy_files_to_backup_host
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.copy_files_to_backup_host
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/backup/copy_files_to_backup_host/meta/main.yml
+++ b/roles/backup/copy_files_to_backup_host/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/backup/copy_files_to_execution_engine/README.md
+++ b/roles/backup/copy_files_to_execution_engine/README.md
@@ -1,0 +1,35 @@
+# Role: copy_files_to_execution_engine
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.copy_files_to_execution_engine
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/backup/copy_files_to_execution_engine/meta/main.yml
+++ b/roles/backup/copy_files_to_execution_engine/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/backup/create_backup_path/README.md
+++ b/roles/backup/create_backup_path/README.md
@@ -1,0 +1,35 @@
+# Role: create_backup_path
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_backup_path
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/backup/create_backup_path/meta/main.yml
+++ b/roles/backup/create_backup_path/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/copy_ucs_file/README.md
+++ b/roles/f5_destination/copy_ucs_file/README.md
@@ -1,0 +1,35 @@
+# Role: copy_ucs_file
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.copy_ucs_file
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/copy_ucs_file/meta/main.yml
+++ b/roles/f5_destination/copy_ucs_file/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/copy_ucs_file_seq/README.md
+++ b/roles/f5_destination/copy_ucs_file_seq/README.md
@@ -1,0 +1,35 @@
+# Role: copy_ucs_file_seq
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.copy_ucs_file_seq
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/copy_ucs_file_seq/meta/main.yml
+++ b/roles/f5_destination/copy_ucs_file_seq/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/create_f5_os_tenant/README.md
+++ b/roles/f5_destination/create_f5_os_tenant/README.md
@@ -1,0 +1,35 @@
+# Role: create_f5_os_tenant
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_f5_os_tenant
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/create_f5_os_tenant/meta/main.yml
+++ b/roles/f5_destination/create_f5_os_tenant/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/create_f5_os_tenant_ha/README.md
+++ b/roles/f5_destination/create_f5_os_tenant_ha/README.md
@@ -1,0 +1,35 @@
+# Role: create_f5_os_tenant_ha
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_f5_os_tenant_ha
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/create_f5_os_tenant_ha/meta/main.yml
+++ b/roles/f5_destination/create_f5_os_tenant_ha/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/create_f5_os_tenant_ha_seq/README.md
+++ b/roles/f5_destination/create_f5_os_tenant_ha_seq/README.md
@@ -1,0 +1,35 @@
+# Role: create_f5_os_tenant_ha_seq
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_f5_os_tenant_ha_seq
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/create_f5_os_tenant_ha_seq/meta/main.yml
+++ b/roles/f5_destination/create_f5_os_tenant_ha_seq/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/pause_5_minutes/README.md
+++ b/roles/f5_destination/pause_5_minutes/README.md
@@ -1,0 +1,35 @@
+# Role: pause_5_minutes
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.pause_5_minutes
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/pause_5_minutes/meta/main.yml
+++ b/roles/f5_destination/pause_5_minutes/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/restore_crypto_keys/README.md
+++ b/roles/f5_destination/restore_crypto_keys/README.md
@@ -1,0 +1,35 @@
+# Role: restore_crypto_keys
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.restore_crypto_keys
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/restore_crypto_keys/meta/main.yml
+++ b/roles/f5_destination/restore_crypto_keys/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/restore_ucs/README.md
+++ b/roles/f5_destination/restore_ucs/README.md
@@ -1,0 +1,35 @@
+# Role: restore_ucs
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.restore_ucs
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/restore_ucs/meta/main.yml
+++ b/roles/f5_destination/restore_ucs/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/restore_ucs_seq/README.md
+++ b/roles/f5_destination/restore_ucs_seq/README.md
@@ -1,0 +1,35 @@
+# Role: restore_ucs_seq
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.restore_ucs_seq
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/restore_ucs_seq/meta/main.yml
+++ b/roles/f5_destination/restore_ucs_seq/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/restore_ucs_wait/README.md
+++ b/roles/f5_destination/restore_ucs_wait/README.md
@@ -1,0 +1,35 @@
+# Role: restore_ucs_wait
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.restore_ucs_wait
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/restore_ucs_wait/meta/main.yml
+++ b/roles/f5_destination/restore_ucs_wait/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/restore_ucs_wait_ha/README.md
+++ b/roles/f5_destination/restore_ucs_wait_ha/README.md
@@ -1,0 +1,35 @@
+# Role: restore_ucs_wait_ha
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.restore_ucs_wait_ha
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/restore_ucs_wait_ha/meta/main.yml
+++ b/roles/f5_destination/restore_ucs_wait_ha/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/set_admin_password_shell/README.md
+++ b/roles/f5_destination/set_admin_password_shell/README.md
@@ -1,0 +1,35 @@
+# Role: set_admin_password_shell
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.set_admin_password_shell
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/set_admin_password_shell/meta/main.yml
+++ b/roles/f5_destination/set_admin_password_shell/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/start_f5_os_tenant/README.md
+++ b/roles/f5_destination/start_f5_os_tenant/README.md
@@ -1,0 +1,35 @@
+# Role: start_f5_os_tenant
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.start_f5_os_tenant
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/start_f5_os_tenant/meta/main.yml
+++ b/roles/f5_destination/start_f5_os_tenant/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/start_f5_os_tenant_ha/README.md
+++ b/roles/f5_destination/start_f5_os_tenant_ha/README.md
@@ -1,0 +1,35 @@
+# Role: start_f5_os_tenant_ha
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.start_f5_os_tenant_ha
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/start_f5_os_tenant_ha/meta/main.yml
+++ b/roles/f5_destination/start_f5_os_tenant_ha/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_destination/start_f5_os_tenant_ha_seq/README.md
+++ b/roles/f5_destination/start_f5_os_tenant_ha_seq/README.md
@@ -1,0 +1,35 @@
+# Role: start_f5_os_tenant_ha_seq
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.start_f5_os_tenant_ha_seq
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_destination/start_f5_os_tenant_ha_seq/meta/main.yml
+++ b/roles/f5_destination/start_f5_os_tenant_ha_seq/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/backup_crypto_keys/README.md
+++ b/roles/f5_source/backup_crypto_keys/README.md
@@ -1,0 +1,35 @@
+# Role: backup_crypto_keys
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.backup_crypto_keys
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/backup_crypto_keys/meta/main.yml
+++ b/roles/f5_source/backup_crypto_keys/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/backup_info_variables/README.md
+++ b/roles/f5_source/backup_info_variables/README.md
@@ -1,0 +1,35 @@
+# Role: backup_info_variables
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.backup_info_variables
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/backup_info_variables/meta/main.yml
+++ b/roles/f5_source/backup_info_variables/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/backup_ucs_file/README.md
+++ b/roles/f5_source/backup_ucs_file/README.md
@@ -1,0 +1,35 @@
+# Role: backup_ucs_file
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.backup_ucs_file
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/backup_ucs_file/meta/main.yml
+++ b/roles/f5_source/backup_ucs_file/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/check_f5_availability/README.md
+++ b/roles/f5_source/check_f5_availability/README.md
@@ -1,0 +1,35 @@
+# Role: check_f5_availability
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.check_f5_availability
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/check_f5_availability/meta/main.yml
+++ b/roles/f5_source/check_f5_availability/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/create_aom_user/README.md
+++ b/roles/f5_source/create_aom_user/README.md
@@ -1,0 +1,35 @@
+# Role: create_aom_user
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_aom_user
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/create_aom_user/meta/main.yml
+++ b/roles/f5_source/create_aom_user/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/create_dyn_groups/README.md
+++ b/roles/f5_source/create_dyn_groups/README.md
@@ -1,0 +1,35 @@
+# Role: create_dyn_groups
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.create_dyn_groups
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/create_dyn_groups/meta/main.yml
+++ b/roles/f5_source/create_dyn_groups/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/detect_source/README.md
+++ b/roles/f5_source/detect_source/README.md
@@ -1,0 +1,35 @@
+# Role: detect_source
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.detect_source
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/detect_source/meta/main.yml
+++ b/roles/f5_source/detect_source/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/disable_f5_tmm/README.md
+++ b/roles/f5_source/disable_f5_tmm/README.md
@@ -1,0 +1,35 @@
+# Role: disable_f5_tmm
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.disable_f5_tmm
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/disable_f5_tmm/meta/main.yml
+++ b/roles/f5_source/disable_f5_tmm/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/ha_failover_to_standby/README.md
+++ b/roles/f5_source/ha_failover_to_standby/README.md
@@ -1,0 +1,35 @@
+# Role: ha_failover_to_standby
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.ha_failover_to_standby
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/ha_failover_to_standby/meta/main.yml
+++ b/roles/f5_source/ha_failover_to_standby/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/remove_as3/README.md
+++ b/roles/f5_source/remove_as3/README.md
@@ -1,0 +1,35 @@
+# Role: remove_as3
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.remove_as3
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/remove_as3/meta/main.yml
+++ b/roles/f5_source/remove_as3/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []

--- a/roles/f5_source/update_dyn_groups/README.md
+++ b/roles/f5_source/update_dyn_groups/README.md
@@ -1,0 +1,35 @@
+# Role: update_dyn_groups
+
+## Description
+
+This role is part of the F5 BIG-IP platform modernization collection.
+
+## Requirements
+
+- F5 BIG-IP system
+- Appropriate network connectivity
+- Valid credentials
+
+## Role Variables
+
+See defaults/main.yml for available variables (if present).
+
+## Dependencies
+
+None
+
+## Example Usage
+
+```yaml
+- hosts: f5_devices
+  roles:
+    - f5devcentral.f5_bd_ansible_platform_modernization.update_dyn_groups
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+F5 DevCentral

--- a/roles/f5_source/update_dyn_groups/meta/main.yml
+++ b/roles/f5_source/update_dyn_groups/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: F5 DevCentral
+  description: Role for F5 BIG-IP platform modernization
+  company: F5 Networks
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - f5
+    - bigip
+    - networking
+dependencies: []


### PR DESCRIPTION
Roles need to have README.md files along with metadata otherwise `galaxy-importer` fails. 

Running `galaxy-importer` results in `WARNING: Could not get role description, no role metadata found` and this exception: `galaxy_importer.exceptions.ContentLoadError: No role readme found.`

That appears to come from https://github.com/ansible/galaxy-importer/blob/888e9706f913af88ea903b269ef113444060fc0a/galaxy_importer/loaders/content.py#L250

I couldn't see anywhere in Ansible docs that it says README.md files are required for roles but `galaxy-importer` seems to enforce it. There is a section on the required metadata in docs here though: https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_reuse_roles.html